### PR TITLE
ci(main.yaml): update poetry install command

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,7 +26,7 @@ jobs:
           curl -sSL https://install.python-poetry.org | python3 -
 
       - name: Install dependencies with poetry
-        run: poetry install
+        run: poetry install --no-root
 
       - name: Run pytest
         run: poetry run pytest -v


### PR DESCRIPTION
To correct install the project, we need to use poetry install --no-root, instead of poetry install.