### PR TITLE
ci(main.yaml): fix deply-docs code

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,7 +49,7 @@ jobs:
           curl -sSL https://install.python-poetry.org | python3 -
 
       - name: Install dependencies with poetry
-        run: poetry install --only docs
+        run: poetry install --only docs --no-route
 
       - name: Build and deploy MkDocs site
         run: poetry run mkdocs gh-deploy --force


### PR DESCRIPTION
To correct install the project, we need to use poetry install --no-route instead poetry install.